### PR TITLE
CI: Install python3-rpm, for the PyPI rpm package to use

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,3 +32,4 @@ jobs:
         uses: fedora-python/tox-github-action@main
         with:
           tox_env: ${{ matrix.tox_env }}
+          dnf_install: python3-rpm


### PR DESCRIPTION
The Fedora 41 tox-github-action container no longer has this by default.