### PR TITLE
Improve %pyproject_check_import newline handling

### DIFF
--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -511,7 +511,15 @@ def add_pyproject_check_import(spec: Specfile, sections: Sections) -> ResultMsg:
                 "%check already has %pyproject_check_import",
             )
 
-    sections.check[:0] = ["%pyproject_check_import", ""]
+    check_import = ["%pyproject_check_import"]
+
+    # Add an empty line after %pyproject_check_import if
+    # the current content contains more than one line.
+    if len([l for l in sections.check if l.strip()]) > 1:
+        check_import += [""]
+
+    sections.check[:0] = check_import
+
     return (
         Result.UPDATED,
         "existing %check prepended with %pyproject_check_import",

--- a/tests/__all__.spec
+++ b/tests/__all__.spec
@@ -48,7 +48,6 @@ export CYTHON_COMPILE=1
 
 %check
 %pyproject_check_import
-
 %{__python3} setup.py test
 
 

--- a/tests/py3_install_to_pyproject_install__add_pyproject_files__add_pyproject_check_import.spec
+++ b/tests/py3_install_to_pyproject_install__add_pyproject_files__add_pyproject_check_import.spec
@@ -51,7 +51,6 @@ CYTHON_COMPILE=1 %py3_build -- --use-the-force-luke
 
 %check
 %pyproject_check_import
-
 %{__python3} setup.py test
 
 


### PR DESCRIPTION
Add smart newline logic after %pyproject_check_import based on existing
%check section content (adds blank line if section has empty lines or
is multiline)

This ensures consistent spec file formatting while avoiding unnecessary
blank lines in simple check sections.

The content of the second commit is just what happened when I ran `tox`. Can be removed or kept as you wish.

Should I push updated `specfiles` somewhere for review?