### PR TITLE
Docs: Fake the terminal width, make tox -e doc stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ and completion of the transition is strongly advised.
 
 ```
 $ python pyprojectize.py --help
-usage: pyprojectize [-h] [-l] [-i MODIFIER] [-x MODIFIER [MODIFIER ...] | -o MODIFIER] [-s SOURCEDIR] [SPECFILE]
+usage: pyprojectize [-h] [-l] [-i MODIFIER] [-x MODIFIER [MODIFIER ...] |
+                    -o MODIFIER] [-s SOURCEDIR]
+                    [SPECFILE]
 
 positional arguments:
   SPECFILE              path to the spec file to convert
@@ -39,10 +41,13 @@ options:
                         exclude given modifier
   -o, --only MODIFIER   run only one given modifier
   -s, --sourcedir SOURCEDIR
-                        path to the source directory, relevant for %include etc. (default: spec's parent)
+                        path to the source directory, relevant for %include
+                        etc. (default: spec's parent)
 
-If you wish to process multiple specfiles at a time, run this tool via parallel, etc. If you wish to inspect/commit result of each modififer separatelly, you can loop over pyprojectize -l calling pyprojectize -o $modifer
-each time.
+If you wish to process multiple specfiles at a time, run this tool via
+parallel, etc. If you wish to inspect/commit result of each modififer
+separatelly, you can loop over pyprojectize -l calling pyprojectize -o
+$modifer each time.
 
 $ python pyprojectize.py ampy.spec  # 16a7deeb
 ✅ add_pyproject_buildrequires: %generate_buildrequires with %pyproject_buildrequires added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,4 +56,5 @@ commands = [["black", "."]]
 [tool.tox.env.doc]
 description = "regenerate README"
 deps = ["cogapp", "urllib3"]
+set_env = { COLUMNS = "80" }
 commands = [["cog", "-Pr", "README.md"]]


### PR DESCRIPTION
The output of argparse is terminal-width dependent.