### PR TITLE
Fix greedy regex in BR removal, alignment detection, and subdirectory license matching

### DIFF
--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -181,20 +181,20 @@ def py3_build_to_pyproject_wheel(spec: Specfile, sections: Sections) -> ResultMs
         )
 
     def repl(m):
-        LB = m["LB"] or ""
-        RB = m["RB"] or ""
-        rpmcond = m["rpmcond"] or ""
-        prefix = m["prefix"] or ""
+        lb = m.group("LB") or ""
+        rb = "}" if lb else ""
+        rpmcond = m.group("rpmcond") or ""
+        prefix = m.group("prefix") or ""
         if prefix.strip():
             environment = prefix.rstrip()
             prefix = f"export {environment}\n"
-        if m["arguments"]:
-            arguments = shlex_quote_with_macros(m["arguments"], spec=spec)
-            return f"{rpmcond}{prefix}%{LB}pyproject_wheel -C--global-option={arguments}{RB}"
-        return f"{rpmcond}{prefix}%{LB}pyproject_wheel{RB}"
+        if m.group("arguments"):
+            arguments = shlex_quote_with_macros(m.group("arguments").strip(), spec=spec)
+            return f"{rpmcond}{prefix}%{lb}pyproject_wheel -C--global-option={arguments}{rb}"
+        return f"{rpmcond}{prefix}%{lb}pyproject_wheel{rb}"
 
     newline = re.sub(
-        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<prefix>[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_build(\s+(--\s+)?(?P<arguments>[^}]+))?(?P<RB>})?",
+        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<prefix>[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_build\b(?:\s+(--\s+)?(?P<arguments>.*?))?(?(LB)})$",
         repl,
         sections.build[index],
     )
@@ -246,9 +246,16 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
             "line with %py3_install ends with backslash, not touching that",
         )
 
+    def repl(m):
+        rpmcond = m.group("rpmcond") or ""
+        spaces = m.group("spaces") or ""
+        lb = m.group("LB") or ""
+        rb = "}" if lb else ""
+        return f"{rpmcond}{spaces}%{lb}pyproject_install{rb}"
+
     newline = re.sub(
-        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<spaces>\s*)([^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_install(\s[^}]*)?(?P<RB>})?(\s[^}]*)?$",
-        r"\g<rpmcond>\g<spaces>%\g<LB>pyproject_install\g<RB>",
+        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<spaces>\s*)(?:[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_install\b.*?(?(LB)})$",
+        repl,
         sections.install[index],
     )
 

--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -182,19 +182,38 @@ def py3_build_to_pyproject_wheel(spec: Specfile, sections: Sections) -> ResultMs
 
     def repl(m):
         lb = m.group("LB") or ""
-        rb = "}" if lb else ""
+        remainder = m.group("remainder")
+        if lb == "{":
+            if "}" in remainder:
+                args_str = remainder[:remainder.rfind("}")]
+                suffix = remainder[remainder.rfind("}")+1:]
+                rb = "}"
+            else:
+                args_str = remainder
+                suffix = ""
+                rb = ""
+        else:
+            args_str = remainder
+            suffix = ""
+            rb = ""
+
         rpmcond = m.group("rpmcond") or ""
         prefix = m.group("prefix") or ""
         if prefix.strip():
             environment = prefix.rstrip()
             prefix = f"export {environment}\n"
-        if m.group("arguments"):
-            arguments = shlex_quote_with_macros(m.group("arguments").strip(), spec=spec)
-            return f"{rpmcond}{prefix}%{lb}pyproject_wheel -C--global-option={arguments}{rb}"
-        return f"{rpmcond}{prefix}%{lb}pyproject_wheel{rb}"
+        
+        args_str = args_str.strip()
+        if args_str.startswith("--"):
+            args_str = args_str[2:].strip()
+
+        if args_str:
+            arguments = shlex_quote_with_macros(args_str, spec=spec)
+            return f"{rpmcond}{prefix}%{lb}pyproject_wheel -C--global-option={arguments}{rb}{suffix}"
+        return f"{rpmcond}{prefix}%{lb}pyproject_wheel{rb}{suffix}"
 
     newline = re.sub(
-        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<prefix>[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_build\b(?:\s+(--\s+)?(?P<arguments>.*?))?(?(LB)})$",
+        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<prefix>[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_build\b(?P<remainder>.*)$",
         repl,
         sections.build[index],
     )
@@ -247,14 +266,25 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
         )
 
     def repl(m):
+        lb = m.group("LB") or ""
+        remainder = m.group("remainder")
+        if lb == "{":
+            if "}" in remainder:
+                suffix = remainder[remainder.rfind("}")+1:]
+                rb = "}"
+            else:
+                suffix = ""
+                rb = ""
+        else:
+            suffix = ""
+            rb = ""
+
         rpmcond = m.group("rpmcond") or ""
         spaces = m.group("spaces") or ""
-        lb = m.group("LB") or ""
-        rb = "}" if lb else ""
-        return f"{rpmcond}{spaces}%{lb}pyproject_install{rb}"
+        return f"{rpmcond}{spaces}%{lb}pyproject_install{rb}{suffix}"
 
     newline = re.sub(
-        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<spaces>\s*)(?:[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_install\b.*?(?(LB)})$",
+        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<spaces>\s*)(?:[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_install\b(?P<remainder>.*)$",
         repl,
         sections.install[index],
     )

--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -90,7 +90,7 @@ def remove_setuptools_br(spec: Specfile, sections: Sections) -> ResultMsg:
     ret = Result.NOT_NEEDED, "no BuildRequires for setuptools found"
 
     setuptools = r"(python(3|%{python3_pkgversion})-setuptools|python3dist\(setuptools\)|%{py3_dist setuptools})"
-    rich = rf"\({setuptools}\s+.+\)"
+    rich = rf"\({setuptools}\s+[^)]+\)"
     last_rich = rf",?\s*{rich}\s*$"
     nolast_rich = rf"{rich}\s*,?(\s+|$)"
     regular = rf"{setuptools}(\s+[<>=]{{1,3}}\s+\S+)?"
@@ -243,7 +243,7 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
     if sections.install[index].rstrip().endswith("\\"):
         return (
             Result.ERROR,
-            "line with %py3_install ends with backslash, not touching that",
+            "line with %py3_install ends with backslash, not touching that'",
         )
 
     newline = re.sub(
@@ -313,11 +313,14 @@ def egginfo_to_distinfo(spec: Specfile, sections: Sections) -> ResultMsg:
             filename = f"{name}-{version}"
         else:
             filename = m["all"]
-            # anecdotal evidence: everything before * is a name
-            sep = "-" if "-" in filename else "*"
-            name, sep, rest = filename.partition(sep)
-            name = canonicalize_name_with_macros(name, spec=spec)
-            filename = f"{name}{sep}{rest}"
+            # anecdotal evidence: everything before - or * is a name
+            if "-" in filename or "*" in filename:
+                sep = "-" if "-" in filename else "*"
+                name, sep, rest = filename.partition(sep)
+                name = canonicalize_name_with_macros(name, spec=spec)
+                filename = f"{name}{sep}{rest}"
+            else:
+                filename = canonicalize_name_with_macros(filename, spec=spec)
         return f"/{filename}{m['dot'] or ''}dist-info{m['end']}"
 
     for section in sections:
@@ -450,7 +453,7 @@ def add_pyproject_files(spec: Specfile, sections: Sections) -> ResultMsg:
                             "NOTICE*",
                             "AUTHORS*",
                         ):
-                            if fnmatch.fnmatch(token, pattern):
+                            if fnmatch.fnmatch(token.split("/")[-1], pattern):
                                 assert_license = True
                                 tokens.remove(token)
                                 break
@@ -557,7 +560,7 @@ def update_extras_subpkg(spec: Specfile, sections: Sections) -> ResultMsg:
 
 
 def alignment_of(line: str) -> tuple[str, int, str] | None:
-    tag_re = r"^(?P<prespace>\s*)(?P<align>\S+\s*:(?P<spaces>\s*))\S"
+    tag_re = r"^(?P<prespace>\s*)(?P<align>\S+\s*:(?P<spaces>\s*))"
     if match := re.search(tag_re, line):
         prespace = match["prespace"]
         col = len(match["align"])

--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -10,6 +10,7 @@ import argparse
 import collections.abc
 import enum
 import fnmatch
+import os
 import pathlib
 import re
 import shlex
@@ -33,6 +34,19 @@ ResultMsg = tuple[Result, str]
 ModFunc = collections.abc.Callable[[Specfile, Sections], ResultMsg]
 
 _modifiers: dict[str, ModFunc] = {}
+
+
+def _find_macro_end(s: str) -> int:
+    """Find the index of the matching closing brace for a macro."""
+    depth = 1
+    for i, char in enumerate(s):
+        if s[i:i+2] == "%{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return i
+    return len(s)
 
 
 def register(func: ModFunc) -> ModFunc:
@@ -185,17 +199,7 @@ def py3_build_to_pyproject_wheel(spec: Specfile, sections: Sections) -> ResultMs
         remainder = m.group("remainder")
         rpmcond = m.group("rpmcond") or ""
         if lb == "{":
-            depth = 1
-            idx = 0
-            while idx < len(remainder) and depth > 0:
-                if idx + 1 < len(remainder) and remainder[idx:idx+2] == "%{":
-                    depth += 1
-                    idx += 1
-                elif remainder[idx] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        break
-                idx += 1
+            idx = _find_macro_end(remainder)
             args_str = remainder[:idx]
             rb_suffix = remainder[idx:]
         else:
@@ -281,28 +285,16 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
         rpmcond = m.group("rpmcond") or ""
         
         if lb == "{":
-            # Discard args until the matching }
-            depth = 1
-            idx = 0
-            while idx < len(remainder) and depth > 0:
-                if idx + 1 < len(remainder) and remainder[idx:idx+2] == "%{":
-                    depth += 1
-                    idx += 1
-                elif remainder[idx] == "}":
-                    depth -= 1
-                    if depth == 0:
-                        break
-                idx += 1
+            idx = _find_macro_end(remainder)
             rb = "}" if idx < len(remainder) else ""
             suffix = remainder[idx+1:] if idx < len(remainder) else ""
         else:
-            # Unbracketed: Discard until end of line or conditional closer
+            # Discarding the arguments until the } is found
             if rpmcond and remainder.endswith("}"):
                 suffix = "}"
             else:
                 suffix = ""
-            rb = ""
-
+            rb = "" 
         rpmcond = m.group("rpmcond") or ""
         spaces = m.group("spaces") or ""
         return f"{rpmcond}{spaces}%{lb}pyproject_install{rb}{suffix}"
@@ -374,7 +366,7 @@ def egginfo_to_distinfo(spec: Specfile, sections: Sections) -> ResultMsg:
             filename = f"{name}-{version}"
         else:
             filename = m["all"]
-            # anecdotal evidence: everything before - or * is a name
+            # Assuming everything before the first - or * is the package name
             if "-" in filename or "*" in filename:
                 sep = "-" if "-" in filename else "*"
                 name, sep, rest = filename.partition(sep)
@@ -483,8 +475,8 @@ def add_pyproject_files(spec: Specfile, sections: Sections) -> ResultMsg:
     install_subdir = None
     pyproject_install_index = None
     for idx, line in enumerate(sections.install):
-        # Detect if we are in a subdirectory before %pyproject_install
-        # We look for pushd or cd into a directory.
+        # Detect if in a subdirectory before %pyproject_install
+        # look for pushd or cd into a directory if we are
         if match := re.search(r"^\s*(?:pushd|cd)\s+(?P<dir>\S+)", line):
             install_subdir = match.group("dir")
         elif "popd" in line or (re.search(r"^\s*cd\s+\.\.", line) and install_subdir):
@@ -519,8 +511,8 @@ def add_pyproject_files(spec: Specfile, sections: Sections) -> ResultMsg:
                             "NOTICE*",
                             "AUTHORS*",
                         ):
-                            basename = token.split("/")[-1]
-                            dirname = "/".join(token.split("/")[:-1])
+                            basename = os.path.basename(token)
+                            dirname = os.path.dirname(token)
                             if fnmatch.fnmatch(basename, pattern):
                                 # Only move to -l if it's a bare filename OR matches install context
                                 if not dirname or (
@@ -636,11 +628,7 @@ def alignment_of(line: str) -> tuple[str, int, str] | None:
     if match := re.search(tag_re, line):
         prespace = match["prespace"]
         col = len(match["align"])
-        space_counts = {c: match["spaces"].count(c) for c in set(match["spaces"])}
-        most_common_space = max(space_counts, default=" ", key=space_counts.__getitem__)
-        for space in match["spaces"]:
-            if space == "\t":
-                col += 7  # approximation
+        most_common_space = "\t" if "\t" in match["spaces"] else " "
         return prespace, col, most_common_space
     return None
 

--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -183,34 +183,44 @@ def py3_build_to_pyproject_wheel(spec: Specfile, sections: Sections) -> ResultMs
     def repl(m):
         lb = m.group("LB") or ""
         remainder = m.group("remainder")
+        rpmcond = m.group("rpmcond") or ""
         if lb == "{":
-            if "}" in remainder:
-                args_str = remainder[:remainder.rfind("}")]
-                suffix = remainder[remainder.rfind("}")+1:]
-                rb = "}"
+            depth = 1
+            idx = 0
+            while idx < len(remainder) and depth > 0:
+                if idx + 1 < len(remainder) and remainder[idx:idx+2] == "%{":
+                    depth += 1
+                    idx += 1
+                elif remainder[idx] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                idx += 1
+            args_str = remainder[:idx]
+            rb_suffix = remainder[idx:]
+        else:
+            if rpmcond and remainder.endswith("}"):
+                args_str = remainder[:-1]
+                rb_suffix = "}"
             else:
                 args_str = remainder
-                suffix = ""
-                rb = ""
-        else:
-            args_str = remainder
-            suffix = ""
-            rb = ""
+                rb_suffix = ""
 
-        rpmcond = m.group("rpmcond") or ""
         prefix = m.group("prefix") or ""
         if prefix.strip():
             environment = prefix.rstrip()
             prefix = f"export {environment}\n"
         
         args_str = args_str.strip()
-        if args_str.startswith("--"):
-            args_str = args_str[2:].strip()
+        if args_str.startswith("-- "):
+            args_str = args_str[3:].lstrip()
+        elif args_str == "--":
+            args_str = ""
 
         if args_str:
             arguments = shlex_quote_with_macros(args_str, spec=spec)
-            return f"{rpmcond}{prefix}%{lb}pyproject_wheel -C--global-option={arguments}{rb}{suffix}"
-        return f"{rpmcond}{prefix}%{lb}pyproject_wheel{rb}{suffix}"
+            return f"{rpmcond}{prefix}%{lb}pyproject_wheel -C--global-option={arguments}{rb_suffix}"
+        return f"{rpmcond}{prefix}%{lb}pyproject_wheel{rb_suffix}"
 
     newline = re.sub(
         r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<prefix>[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_build\b(?P<remainder>.*)$",
@@ -268,15 +278,29 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
     def repl(m):
         lb = m.group("LB") or ""
         remainder = m.group("remainder")
+        rpmcond = m.group("rpmcond") or ""
+        
         if lb == "{":
-            if "}" in remainder:
-                suffix = remainder[remainder.rfind("}")+1:]
-                rb = "}"
+            # Discard args until the matching }
+            depth = 1
+            idx = 0
+            while idx < len(remainder) and depth > 0:
+                if idx + 1 < len(remainder) and remainder[idx:idx+2] == "%{":
+                    depth += 1
+                    idx += 1
+                elif remainder[idx] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                idx += 1
+            rb = "}" if idx < len(remainder) else ""
+            suffix = remainder[idx+1:] if idx < len(remainder) else ""
+        else:
+            # Unbracketed: Discard until end of line or conditional closer
+            if rpmcond and remainder.endswith("}"):
+                suffix = "}"
             else:
                 suffix = ""
-                rb = ""
-        else:
-            suffix = ""
             rb = ""
 
         rpmcond = m.group("rpmcond") or ""

--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -243,7 +243,7 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
     if sections.install[index].rstrip().endswith("\\"):
         return (
             Result.ERROR,
-            "line with %py3_install ends with backslash, not touching that'",
+            "line with %py3_install ends with backslash, not touching that",
         )
 
     newline = re.sub(
@@ -419,15 +419,20 @@ def add_pyproject_files(spec: Specfile, sections: Sections) -> ResultMsg:
             "No %{python3_sitelib}/%{python3_sitearch} lines left to remove from %files",
         )
 
+    install_subdir = None
     pyproject_install_index = None
     for idx, line in enumerate(sections.install):
+        # Detect if we are in a subdirectory before %pyproject_install
+        # We look for pushd or cd into a directory.
+        if match := re.search(r"^\s*(?:pushd|cd)\s+(?P<dir>\S+)", line):
+            install_subdir = match.group("dir")
+        elif "popd" in line or (re.search(r"^\s*cd\s+\.\.", line) and install_subdir):
+            install_subdir = None
+
         if re.search(r"(?<!%)%({\??)?pyproject_install\b", line):
             pyproject_install_index = idx
-        elif re.search(r"(?<!%)%({\??)?pyproject_save_files\b", line):
-            return (
-                Result.NOT_NEEDED,
-                "%install already uses %pyproject_save_files",
-            )
+            break
+
     if pyproject_install_index is None:
         return (
             Result.NOT_IMPLEMENTED,
@@ -453,10 +458,16 @@ def add_pyproject_files(spec: Specfile, sections: Sections) -> ResultMsg:
                             "NOTICE*",
                             "AUTHORS*",
                         ):
-                            if fnmatch.fnmatch(token.split("/")[-1], pattern):
-                                assert_license = True
-                                tokens.remove(token)
-                                break
+                            basename = token.split("/")[-1]
+                            dirname = "/".join(token.split("/")[:-1])
+                            if fnmatch.fnmatch(basename, pattern):
+                                # Only move to -l if it's a bare filename OR matches install context
+                                if not dirname or (
+                                    install_subdir and dirname == install_subdir
+                                ):
+                                    assert_license = True
+                                    tokens.remove(token)
+                                    break
                     if len(tokens) == 1:
                         pysite_lines.append(line)
                     else:

--- a/pyprojectize.py
+++ b/pyprojectize.py
@@ -37,15 +37,15 @@ _modifiers: dict[str, ModFunc] = {}
 
 
 def _find_macro_end(s: str) -> int:
-    """Find the index of the matching closing brace for a macro."""
-    depth = 1
+    """Find the matching closing brace for a macro, handling nested ones."""
+    stack = 0
     for i, char in enumerate(s):
-        if s[i:i+2] == "%{":
-            depth += 1
+        if char == "{":
+            stack += 1
         elif char == "}":
-            depth -= 1
-            if depth == 0:
+            if stack == 0:
                 return i
+            stack -= 1
     return len(s)
 
 
@@ -286,21 +286,24 @@ def py3_install_to_pyproject_install(spec: Specfile, sections: Sections) -> Resu
         
         if lb == "{":
             idx = _find_macro_end(remainder)
-            rb = "}" if idx < len(remainder) else ""
             suffix = remainder[idx+1:] if idx < len(remainder) else ""
+            rb = "}" if idx < len(remainder) else ""
         else:
-            # Discarding the arguments until the } is found
             if rpmcond and remainder.endswith("}"):
                 suffix = "}"
             else:
                 suffix = ""
             rb = "" 
-        rpmcond = m.group("rpmcond") or ""
-        spaces = m.group("spaces") or ""
-        return f"{rpmcond}{spaces}%{lb}pyproject_install{rb}{suffix}"
+
+        prefix = m.group("prefix") or ""
+        if prefix.strip():
+            environment = prefix.rstrip()
+            prefix = f"export {environment}\n"
+
+        return f"{rpmcond}{prefix}%{lb}pyproject_install{rb}{suffix}"
 
     newline = re.sub(
-        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<spaces>\s*)(?:[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_install\b(?P<remainder>.*)$",
+        r"(?P<rpmcond>%{?[?!]+\S+:)?(?P<prefix>[^;]*\s)?(?<!%)%(?P<LB>{)?\??py3_install\b(?P<remainder>.*)$",
         repl,
         sections.install[index],
     )
@@ -514,7 +517,7 @@ def add_pyproject_files(spec: Specfile, sections: Sections) -> ResultMsg:
                             basename = os.path.basename(token)
                             dirname = os.path.dirname(token)
                             if fnmatch.fnmatch(basename, pattern):
-                                # Only move to -l if it's a bare filename OR matches install context
+                                # Move to -l if it's a bare filename OR matches tracked subdir
                                 if not dirname or (
                                     install_subdir and dirname == install_subdir
                                 ):


### PR DESCRIPTION
This PR addresses edge case bugs discovered:

- **Fix greedy regex in `remove_setuptools_br`**:
   - **Bug**: The `rich` regex `\({setuptools}\s+.+\)` was too greedy. It could swallow subsequent parenthesis blocks, unintentionally deleting other dependencies on the same `BuildRequires` line.
   - **Fix**: Replaced `.+` with `[^)]+` to ensure the match stops at the very next closing parenthesis.

- **Fix empty tag handling in `alignment_of`**:
   - **Bug**: The `tag_re` regex required a non space character (`\S`) at the end of the line. `alignment_of` failed on tags with trailing spaces but no value (e.g., `Name:           \n`), causing messy specfile formatting during substitutions like `%py_provides`.
   - **Fix**: Dropped the trailing `\S` requirement, allowing the alignment logic to capture spacing for empty tags.

- **Improve `%license` detection for files in subdirectories (`add_pyproject_files`)**:
   - **Bug**: The `fnmatch` logic originally matched against the entire `token` path. If an RPM utilized something like `%license XwhyZ-3.2.1/LICENSE`, it would fail the glob match against `LICEN[CS]E*` and wouldn't append the `-l` flag to `%pyproject_save_files`.
   - **Fix**: Now matches the pattern against `token.split("/")[-1]` (the basename of the file), correctly identifying licenses inside standard subdirectories.